### PR TITLE
make subdomain generation and redirection work with non-default ports

### DIFF
--- a/Code_Igniter/application/config/config.php
+++ b/Code_Igniter/application/config/config.php
@@ -18,12 +18,16 @@
 // dynamic base url to allow subdomains (also incorporates https:// if used)
 if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on"){
 	$ssl_set = "s";
+	$default_port = 443;
 }
 else{
 	$ssl_set = "";
-}  
-//$config['base_url'] = 'http'.$ssl_set.'://enketo.formhub.org/';//$_SERVER['HTTP_HOST'];  
-$config['base_url'] = substr($_SERVER['HTTP_HOST'], strpos($_SERVER['HTTP_HOST'], 'enketo'));
+	$default_port = 80;
+}
+//$config['base_url'] = 'http'.$ssl_set.'://enketo.formhub.org/';
+//$config['base_url'] = substr($_SERVER['HTTP_HOST'], strpos($_SERVER['HTTP_HOST'], 'enketo'));
+$config['base_url'] = substr($_SERVER['SERVER_NAME'], strpos($_SERVER['SERVER_NAME'], 'enketo'));
+if($_SERVER['SERVER_PORT'] != $default_port) $config['base_url'] .=  ':' . $_SERVER['SERVER_PORT'];
 
 /*
 |--------------------------------------------------------------------------

--- a/Code_Igniter/application/controllers/forms.php
+++ b/Code_Igniter/application/controllers/forms.php
@@ -78,7 +78,7 @@ class Forms extends CI_Controller {
 		{
 			$result = $this->Form_model->get_formlist_JSON($server_url);
 			$this->output
-				->set_content_type('applicaton/json')
+				->set_content_type('application/json')
 				->set_output(json_encode($result)); 
 		}
 		else 

--- a/Code_Igniter/application/helpers/subdomain_helper.php
+++ b/Code_Igniter/application/helpers/subdomain_helper.php
@@ -42,15 +42,18 @@ if ( ! function_exists('get_subdomain'))
 {
 	function get_subdomain($default = NULL)
 	{ 
-		$full_name = $_SERVER['SERVER_NAME'];		
 		$full_url = full_base_url(); 
-
-		if ($full_url != base_url())
+		$base_url = base_url();
+		
+		if ($full_url != $base_url)
 		{		
-			log_message('debug', 'full_name '.$full_name);
-			$base_name = substr(base_url(), strpos(base_url(), '://'), -1);
+			log_message('debug', 'full_url '.$full_url);
+			$base_name = substr($base_url, strpos($base_url, '://'), -1);
 			log_message('debug', 'base_name '.$base_name);
-			$subdomain_name = substr($full_name, 0, strpos($full_name, '.'.$base_name));
+			$start = strpos($full_url, '://') + 3;
+			$end = strpos($full_url, '.'.$base_name);
+			if($start < $end) $subdomain_name = substr($full_url, $start , $end - $start);
+			else $subdomain_name = '';
 			log_message('debug', 'subdomain extracted: '.$subdomain_name);
 		}
 	 
@@ -66,9 +69,19 @@ if ( ! function_exists('get_subdomain'))
 if ( ! function_exists('full_base_url') )
 {
 	function full_base_url($path=''){
-		$full_name = $_SERVER['SERVER_NAME'].'/'.$path;
+		if(empty($_SERVER['HTTPS'])) {
+			$protocol = 'http://';
+			$default_port = 80;
+		} else {
+			$protocol = 'https://';
+			$default_port = 443;
+		}
+        $domain = $_SERVER['SERVER_NAME'];
+		// append port to domain only if it's a nonstandard port. don't use HTTP_HOST as it can be manipulated by the client
+		if($_SERVER['SERVER_PORT'] != $default_port) $domain .=  ':' . $_SERVER['SERVER_PORT'];
+		$domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain; 
 
-		return (isset($_SERVER['HTTPS'])) ? 'https://'.$full_name : 'http://'.$full_name;
+		return $protocol.$domain . '/'.$path;
 	}
 }
 

--- a/Code_Igniter/application/models/survey_model.php
+++ b/Code_Igniter/application/models/survey_model.php
@@ -214,6 +214,27 @@ class Survey_model extends CI_Model {
         return $this->_get_record_number();
     }
 
+	private function _get_base_url($subdomain = false, $suffix = false) {
+		if(empty($_SERVER['HTTPS'])) {
+			$protocol = 'http://';
+			$default_port = 80;
+		} else {
+			$protocol = 'https://';
+			$default_port = 443;
+		}
+        $domain = $_SERVER['SERVER_NAME'];
+		// append port to domain only if it's a nonstandard port. don't use HTTP_HOST as it can be manipulated by the client
+		if($_SERVER['SERVER_PORT'] != $default_port) $domain .=  ':' . $_SERVER['SERVER_PORT'];
+		$domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain; 
+
+		if($subdomain) {
+			if($suffix) 
+				$subdomain .= $this->ONLINE_SUBDOMAIN_SUFFIX;
+			$subdomain .= '.';
+		}
+		return $protocol.$subdomain.$domain;
+	}
+
     /**
      * @method _get_full_survey_url turns a subdomain into the full url where the survey is available
      * 
@@ -221,10 +242,7 @@ class Survey_model extends CI_Model {
      */
     private function _get_full_survey_url($subdomain)
     {
-        $protocol = (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
-        $domain = $_SERVER['SERVER_NAME'];
-        $domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain; 
-        return $protocol.$subdomain.'.'.$domain.'/webform';
+        return $this->_get_base_url($subdomain).'/webform';
     }
 
     /**
@@ -234,10 +252,7 @@ class Survey_model extends CI_Model {
      */
     private function _get_full_survey_edit_url($subdomain)
     {
-        $protocol = (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
-        $domain = $_SERVER['SERVER_NAME'];
-        $domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain; 
-        return $protocol.$subdomain.($this->ONLINE_SUBDOMAIN_SUFFIX).'.'.$domain.'/webform/edit';
+        return $this->_get_base_url($subdomain, true).'/webform/edit';
     }
 
     /**
@@ -247,10 +262,7 @@ class Survey_model extends CI_Model {
      */
     private function _get_full_survey_iframe_url($subdomain)
     {
-        $protocol = (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
-        $domain = $_SERVER['SERVER_NAME'];
-        $domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain; 
-        return $protocol.$subdomain.($this->ONLINE_SUBDOMAIN_SUFFIX).'.'.$domain.'/webform/iframe';
+        return $this->_get_base_url($subdomain, true).'/webform/iframe';
     }
 
     /**
@@ -258,10 +270,7 @@ class Survey_model extends CI_Model {
      */
     private function _get_preview_url($server_url, $form_id)
     {
-        $protocol = (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
-        $domain = $_SERVER['SERVER_NAME'];
-        $domain = (strpos($domain, 'www.') === 0 ) ? substr($domain, 4) : $domain;
-        return $protocol.$domain.'/webform/preview?server='.$server_url.'&id='.$form_id;
+        return $this->_get_base_url().'/webform/preview?server='.$server_url.'&id='.$form_id;
     }
 
 
@@ -391,7 +400,7 @@ class Survey_model extends CI_Model {
         }
         else 
         {
-            log_message('error', 'db query for '.implode(', ', $items)).' returned '.$query_num_rows().' results.';
+            log_message('error', 'db query for '.implode(', ', $items)).' returned '.$query->num_rows().' results.';
             return NULL;   
         }
     }


### PR DESCRIPTION
Hey,

I substituted HTTP_HOST with SERVER_NAME where used because the former can be manipulated by the client
it could be cleaned up more to minimise code duplication, I wanted to get it to work first and I have to delve a little deeper into CIs structure to do that. 
but we could probably do more with the the subdomain helper in the survey model?
